### PR TITLE
🔨 Refactor: Add comments

### DIFF
--- a/threadTest.py
+++ b/threadTest.py
@@ -13,9 +13,9 @@ def urlCrawler(q):
         print(domain)
         t = threading.Thread(target=threadUrlCrawler, args=(domain, q))
         t.start()
-    
+    # 此處有隱憂，但有點難測試出來
     t.join()
-
+    
 
 def threadUrlCrawler(domain, q):
     resp = requests.get(domain)

--- a/webCrawler.py
+++ b/webCrawler.py
@@ -21,7 +21,6 @@ class ＷebCrawler():
         return newDomainList
 
 
-
 if __name__ == "__main__":
 
     inputParams = sys.argv
@@ -32,4 +31,32 @@ if __name__ == "__main__":
 
     while runCount < count:
         runCount += 1
-        domainList = ＷebCrawler.urlCrawler([], domainList)
+        domainList = ＷebCrawler.urlCrawler([], domainList)                
+        """
+        34 行 ＷebCrawler.urlCrawler([], domainList) 雖然 work，但實務上不會這樣寫
+
+        我們可以有２個做法：
+        1. 確實地 instantiation ＷebCrawler 後再呼叫該 instance 的 method 來用
+            e.g.
+                    
+                wc = ＷebCrawler()
+                domainList = wc.urlCrawler(domainList)
+        
+
+        2. 若希望 ＷebCrawler 只是當作一個 namespace，那麼可以將 urlCrawler 改成 "staticmethod"
+            使用 @staticmethod 的修飾器來達成，此時就不需要 self 參數指向自己
+            e.g.
+
+                class ＷebCrawler():
+                    
+                    @staticmethod
+                    def urlCrawler(domainList):
+                        ...
+
+            34 行就可改寫成：
+
+                domainList = ＷebCrawler.urlCrawler(domainList)
+
+            可參考文章了解更多： https://realpython.com/instance-class-and-static-methods-demystified/
+        """
+        


### PR DESCRIPTION
34 行 ＷebCrawler.urlCrawler([], domainList) 雖然 work，但實務上不會這樣寫

我們可以有２個做法：
1. 確實地 instantiation ＷebCrawler 後再呼叫該 instance 的 method 來用
e.g.                    
```python
wc = ＷebCrawler()
domainList = wc.urlCrawler(domainList)
```

2. 若希望 ＷebCrawler 只是當作一個 namespace，那麼可以將 urlCrawler 改成 "staticmethod"
    使用 `@staticmethod` 的修飾器來達成，此時就不需要 self 參數指向自己
e.g.
```python
class ＷebCrawler():
    
    @staticmethod
    def urlCrawler(domainList):
        ...
```
使用了 staticmethod 之後，34 行就可改寫成： `domainList = ＷebCrawler.urlCrawler(domainList)`

可參考文章了解更多 staticmethod（還有與它時常一起討論的 classmethod）：
https://realpython.com/instance-class-and-static-methods-demystified/

---

多執行緒的版本有一個隱憂，while 中不斷從 queue 中取出 URL 邊 create thread，你的 main thread 會因為 queue 空了之後來到 line 16(17) 的 join()

但隱憂是，此時的 t 物件只是你最後一個 create  的 thread
> 實務上也會避免這種寫法，如果是變數作用域較嚴謹的語言這樣會出錯、外面的 scope 看不到 while 裡面的 local variable。雖然 python 在 for / while / if 等 scope 內宣告的變數在外層看得到，但還是盡量避免這樣用，就怕上述的 block 其實因為條件不滿足而沒有進去

你的 main thread 只會等待最後一條 thread 做完
要是此時你這是第 15 條 thread，剛好做得飛快，那可能前面 14 條 thread 的結果、可能就會因為 main thread 繼續走下去而遺失